### PR TITLE
Fallback to siteId option if projectId is not available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var integration = require('@segment/analytics.js-integration')
 var Asayer = module.exports = integration('asayer')
   .global('asayer')
   .option('projectId', null)
+  .option('siteId', null) // Retain siteId for backwards compatibility.
   .option('obscureTextNumbers', false)
   .option('obscureTextEmails', false)
   .tag('<script src="https://static.asayer.io/tracker.js"></script>')
@@ -20,8 +21,12 @@ function positiveNumber (number) {
 Asayer.prototype.initialize = function () {
   var projectId = positiveNumber(this.options.projectId)
   if (!projectId) {
-    console.warn('Asayer wrong projectId option, not loading.')
-    return
+    // Fall back to siteId.
+    projectId = positiveNumber(this.options.siteId)
+    if (!projectId) {
+      console.warn('Asayer wrong projectId option, not loading.')
+      return
+    }
   }
 
   var r = window.asayer = [projectId, undefined, 28 | (+this.options.obscureTextEmails) | (+this.options.obscureTextNumbers << 1), [0]]


### PR DESCRIPTION
Hello! While we at Segment were looking to bump the version of asayer used by analytics.js we noticed a potential issue. It looks like the version bump moved from using `options.siteId` to `options.projectId`. https://github.com/asayerio/analytics.js-integration-asayer/compare/c0cd0579e2b0761d4c9b78f56514a708c89e52dc..e098c8bc6f9d7297ac64bef6c2d5b9ac28fb87e5

That would be fine (once you add the new setting) except for existing customers. Those existing customers would still have `options.siteId` since there isn't currently a way to migrate their settings over to `options.projectId` automatically. For those customers, I suggest we provide a fallback option so their events are not dropped after performing the upgrade.

This PR is a suggested fallback option. Let me know your thoughts, feel free to merge and publish this new version and we can add it to a.js. Thanks for your help!